### PR TITLE
feat: add onPreBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Google drive picker custom hook.
 ### Installing
 
 With npm
+
 ```
 npm i react-google-drive-picker
 ```
+
 With yarn
+
 ```
 yarn add react-google-drive-picker
 ```
@@ -22,12 +25,11 @@ yarn add react-google-drive-picker
 ### Usage
 
 ```js
-import  { useEffect } from 'react';
-import useDrivePicker from 'react-google-drive-picker'
-
+import { useEffect } from "react";
+import useDrivePicker from "react-google-drive-picker";
 
 function App() {
-  const [openPicker, data, authResponse] = useDrivePicker();  
+  const [openPicker, data, authResponse] = useDrivePicker();
   // const customViewsArray = [new google.picker.DocsView()]; // custom view
   const handleOpenPicker = () => {
     openPicker({
@@ -40,20 +42,19 @@ function App() {
       supportDrives: true,
       multiselect: true,
       // customViews: customViewsArray, // custom view
-    })
-  }
+    });
+  };
 
   useEffect(() => {
     // do anything with the selected/uploaded files
-    if(data){
-      data.docs.map(i => console.log(i.name))
+    if (data) {
+      data.docs.map((i) => console.log(i.name));
     }
-  }, [data])
+  }, [data]);
 
-  
   return (
     <div>
-        <button onClick={() => handleOpenPicker()}>Open Picker</button>
+      <button onClick={() => handleOpenPicker()}>Open Picker</button>
     </div>
   );
 }
@@ -61,51 +62,52 @@ function App() {
 export default App;
 ```
 
-
 ## Picker configuration props
 
 ## Picker Props
 
-|    params        |   value  |  default value   |          description          |
-|------------------|----------|------------------|-------------------------------|
-|    clientId      |  string  |     REQUIRED     |      Google client id         |
-|    developerKey  |  string  |     REQUIRED     |      Google developer key     |
-|    disableDefaultView  |  boolean  |     false     |      disables default view     |
-|    viewId        |  string  |     DOCS         |         ViewIdOptions         |
-|    viewMimeTypes |  string  |     optional     |Comma separated mimetypes. Use this in place of viewId if you need to filter multiple type of files. list: https://developers.google.com/drive/api/v3/mime-types.|
-|setIncludeFolders|  boolean  |     false        |Show folders in the view items.|
-|setSelectFolderEnabled|boolean|     false       |Allows the user to select a folder in Google Drive.|
-|   token          |  string  |     optional     | access_token to skip auth part|
-|  multiselect     |  boolean |     false        | Enable picker multiselect     |
-| supportDrives    |  boolean |     false        |    Support shared drives      |
-| showUploadView   |  boolean |     false        |     Enable upload view        |
-| showUploadFolders|  boolean |     false        |Enable folder selection(upload)|
-| setParentFolder  |  string  |     disabled     |  Drive folder id to upload    |
-| customViews      |ViewClass[]|    optional     |  Array of custom views you want to add to the picker|
-| customScopes      |string[]|    ['https://www.googleapis.com/auth/drive.readonly']     |  Array of custom scopes you want to add to the picker|
-| locale           |string    |    en            | List of supported locales https://developers.google.com/picker/docs#i18n|
+| params                 | value                    | default value                                      | description                                                                                                                                                       |
+| ---------------------- | ------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| clientId               | string                   | REQUIRED                                           | Google client id                                                                                                                                                  |
+| developerKey           | string                   | REQUIRED                                           | Google developer key                                                                                                                                              |
+| disableDefaultView     | boolean                  | false                                              | disables default view                                                                                                                                             |
+| viewId                 | string                   | DOCS                                               | ViewIdOptions                                                                                                                                                     |
+| viewMimeTypes          | string                   | optional                                           | Comma separated mimetypes. Use this in place of viewId if you need to filter multiple type of files. list: https://developers.google.com/drive/api/v3/mime-types. |
+| setIncludeFolders      | boolean                  | false                                              | Show folders in the view items.                                                                                                                                   |
+| setSelectFolderEnabled | boolean                  | false                                              | Allows the user to select a folder in Google Drive.                                                                                                               |
+| token                  | string                   | optional                                           | access_token to skip auth part                                                                                                                                    |
+| multiselect            | boolean                  | false                                              | Enable picker multiselect                                                                                                                                         |
+| supportDrives          | boolean                  | false                                              | Support shared drives                                                                                                                                             |
+| showUploadView         | boolean                  | false                                              | Enable upload view                                                                                                                                                |
+| showUploadFolders      | boolean                  | false                                              | Enable folder selection(upload)                                                                                                                                   |
+| setParentFolder        | string                   | disabled                                           | Drive folder id to upload                                                                                                                                         |
+| customViews            | ViewClass[]              | optional                                           | Array of custom views you want to add to the picker                                                                                                               |
+| customScopes           | string[]                 | ['https://www.googleapis.com/auth/drive.readonly'] | Array of custom scopes you want to add to the picker                                                                                                              |
+| locale                 | string                   | en                                                 | List of supported locales https://developers.google.com/picker/docs#i18n                                                                                          |
+| onPreBuild             | (picker: Picker) => void | false                                              | Optional callback with access to the picker instance                                                                                                              |
 
+## viewId options
 
-  ## viewId options
-|    option            |         description             |
-|----------------------|---------------------------------|
-|    DOCS            |All Google Drive document types. |
-|  DOCS_IMAGES          |Google Drive photos.             
-|DOCS_IMAGES_AND_VIDEOS |Google Drive photos and videos.  |
-|    DOCS_VIDEOS        |Google Drive videos.             |
-|    DOCUMENTS          |	Google Drive Documents.         |
-|    FOLDERS            |Google Drive Folders.            |
-|    DRAWINGS           |Google Drive Drawings.           |
-|    FORMS              |	Google Drive Forms.             |
-|    PDFS               |PDF files stored in Google Drive.|
-|    SPREADSHEETS       |Google Drive Spreadsheets.       |
+| option                 | description                       |
+| ---------------------- | --------------------------------- |
+| DOCS                   | All Google Drive document types.  |
+| DOCS_IMAGES            | Google Drive photos.              |
+| DOCS_IMAGES_AND_VIDEOS | Google Drive photos and videos.   |
+| DOCS_VIDEOS            | Google Drive videos.              |
+| DOCUMENTS              | Google Drive Documents.           |
+| FOLDERS                | Google Drive Folders.             |
+| DRAWINGS               | Google Drive Drawings.            |
+| FORMS                  | Google Drive Forms.               |
+| PDFS                   | PDF files stored in Google Drive. |
+| SPREADSHEETS           | Google Drive Spreadsheets.        |
 
 ## Author
 
 [@Jose medina](https://www.linkedin.com/in/jos%C3%A9-medina-56479a128/)
 
-
 ## Acknowledgments
+
 Inspiration, code snippets
-* [sdoomz](https://github.com/sdoomz/react-google-picker)
-* [obonyojimmy](https://github.com/obonyojimmy/react-drive-picker#readme)
+
+- [sdoomz](https://github.com/sdoomz/react-google-picker)
+- [obonyojimmy](https://github.com/obonyojimmy/react-drive-picker#readme)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "watch": "tsc -w",
     "dev": "nodemon ./dist/index.js",
-    "lint": "eslint 'src/**/*.{js,ts,tsx} --fix"
+    "lint": "eslint 'src/**/*.{js,ts,tsx}' --fix"
   },
   "author": "Jose-cd",
   "repository": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,30 +2,33 @@
 declare let google: any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare let window: any;
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 import {
+  Picker,
   authResult,
   defaultConfiguration,
   PickerCallback,
   PickerConfiguration,
-} from './typeDefs';
-import { useInjectScript } from './useInjectScript';
+} from "./typeDefs";
+import { useInjectScript } from "./useInjectScript";
 
 export default function useDrivePicker(): [
   (config: PickerConfiguration) => boolean | undefined,
-  PickerCallback | undefined, authResult | undefined
+  PickerCallback | undefined,
+  authResult | undefined
 ] {
-  const defaultScopes = ['https://www.googleapis.com/auth/drive.readonly'];
+  const defaultScopes = ["https://www.googleapis.com/auth/drive.readonly"];
   const [loaded, error] = useInjectScript();
   const [pickerApiLoaded, setpickerApiLoaded] = useState(false);
   const [callBackInfo, setCallBackInfo] = useState<PickerCallback>();
   const [openAfterAuth, setOpenAfterAuth] = useState(false);
   const [authWindowVisible, setAuthWindowVisible] = useState(false);
-  const [config, setConfig] = useState<PickerConfiguration>(defaultConfiguration);
-  const [authRes, setAuthRes] = useState<authResult>()
+  const [config, setConfig] =
+    useState<PickerConfiguration>(defaultConfiguration);
+  const [authRes, setAuthRes] = useState<authResult>();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let picker: any;
+  let picker: Picker;
 
   // get the apis from googleapis
   useEffect(() => {
@@ -61,9 +64,9 @@ export default function useDrivePicker(): [
   // load the Drive picker api
   const loadApis = () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    window.gapi.load('auth');
+    window.gapi.load("auth");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    window.gapi.load('picker', { callback: onPickerApiLoad });
+    window.gapi.load("picker", { callback: onPickerApiLoad });
   };
 
   const onPickerApiLoad = () => {
@@ -76,7 +79,9 @@ export default function useDrivePicker(): [
       window.gapi.auth.authorize(
         {
           client_id: config.clientId,
-          scope: config.customScopes ? [...defaultScopes, ...config.customScopes]: defaultScopes,
+          scope: config.customScopes
+            ? [...defaultScopes, ...config.customScopes]
+            : defaultScopes,
           immediate: false,
         },
         handleAuthResult
@@ -87,7 +92,7 @@ export default function useDrivePicker(): [
   const handleAuthResult = (authResult: authResult) => {
     setAuthWindowVisible(false);
     if (authResult && !authResult.error) {
-      setAuthRes(authResult)
+      setAuthRes(authResult);
       setConfig((prev) => ({ ...prev, token: authResult.access_token }));
       setOpenAfterAuth(true);
     }
@@ -95,21 +100,22 @@ export default function useDrivePicker(): [
 
   const createPicker = ({
     token,
-    appId = '',
+    appId = "",
     supportDrives = false,
     developerKey,
-    viewId = 'DOCS',
+    viewId = "DOCS",
     disabled,
     multiselect,
     showUploadView = false,
     showUploadFolders,
-    setParentFolder = '',
+    setParentFolder = "",
     viewMimeTypes,
     customViews,
-    locale = 'en',
+    locale = "en",
     setIncludeFolders,
     setSelectFolderEnabled,
     disableDefaultView = false,
+    onPreBuild,
   }: PickerConfiguration) => {
     if (disabled) return false;
 
@@ -146,7 +152,7 @@ export default function useDrivePicker(): [
     if (supportDrives) {
       picker.enableFeature(google.picker.Feature.SUPPORT_DRIVES);
     }
-
+    if (onPreBuild) onPreBuild(picker);
     picker.build().setVisible(true);
     return true;
   };


### PR DESCRIPTION
# problem

I need access to the `picker` instance, but no API exposes it

# solution

- expose the picker in a `onPreBuild` optional callback, giving the user a handle to the picker once it's been fully configured
- fix lint script
- ...well, my editor ran `prettier` on a few thing on-save 🤦 . i didn't see a format script available in the repo, but i'm happy to apply whatever formatting is desired