### PR TITLE
add viewMimeTypes to uploadView

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,6 +123,7 @@ export default function useDrivePicker(): [
     if (setSelectFolderEnabled) view.setSelectFolderEnabled(true)
 
     const uploadView = new google.picker.DocsUploadView()
+    if (viewMimeTypes) uploadView.setMimeTypes(viewMimeTypes)
     if (showUploadFolders) uploadView.setIncludeFolders(true)
     if (setParentFolder) uploadView.setParent(setParentFolder)
 


### PR DESCRIPTION
Issue: https://github.com/Jose-cd/React-google-drive-picker/issues/14

Currently, we can't set the file type restrictions for the `uploadView` 🙏 