### PR TITLE
Add presentations option for viewId

### DIFF
--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -51,6 +51,7 @@ type ViewIdOptions =
   | 'FORMS'
   | 'PDFS'
   | 'SPREADSHEETS'
+  | 'PRESENTATIONS'
 
 export type PickerConfiguration = {
   clientId: string


### PR DESCRIPTION
Added `PRESENTATIONS` to the `viewId` group.

https://developers.google.com/drive/picker/reference#view-id