### PR TITLE
remove defaultScope from customScope

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,10 +69,9 @@ export default function useDrivePicker(): [
     if (!config.token) {
       const client = google.accounts.oauth2.initTokenClient({
         client_id: config.clientId,
-        scope: (config.customScopes
-          ? [...defaultScopes, ...config.customScopes]
-          : defaultScopes
-        ).join(' '),
+        scope: (config.customScopes ? config.customScopes : defaultScopes).join(
+          ' '
+        ),
         callback: (tokenResponse: authResult) => {
           setAuthRes(tokenResponse)
           createPicker({ ...config, token: tokenResponse.access_token })


### PR DESCRIPTION
Issue: https://github.com/Jose-cd/React-google-drive-picker/issues/25

For cases when we don't need the 'https://www.googleapis.com/auth/drive.readonly' scope and supply our own customScope