### PR TITLE
Add option to set a view search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export default App;
 |    disableDefaultView  |  boolean  |     false     |      disables default view     |
 |    viewId        |  string  |     DOCS         |         ViewIdOptions         |
 |    viewMimeTypes |  string  |     optional     |Comma separated mimetypes. Use this in place of viewId if you need to filter multiple type of files. list: https://developers.google.com/drive/api/v3/mime-types.|
+|    viewQuery    |  string  |     optional     |Used to set a search query i.e. View.searchQuery(viewQuery) |
 |setIncludeFolders|  boolean  |     false        |Show folders in the view items.|
 |setSelectFolderEnabled|boolean|     false       |Allows the user to select a folder in Google Drive.|
 |   token          |  string  |     optional     | access_token to skip auth part|

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -112,6 +112,7 @@ export default function useDrivePicker(): [
     showUploadFolders,
     setParentFolder = '',
     viewMimeTypes,
+    viewQuery,
     customViews,
     locale = 'en',
     setIncludeFolders,
@@ -125,6 +126,7 @@ export default function useDrivePicker(): [
     if (viewMimeTypes) view.setMimeTypes(viewMimeTypes)
     if (setIncludeFolders) view.setSelectFolderEnabled(true)
     if (setSelectFolderEnabled) view.setSelectFolderEnabled(true)
+    if (viewQuery) view.setQuery(viewQuery)
 
     const uploadView = new google.picker.DocsUploadView()
     if (viewMimeTypes) uploadView.setMimeTypes(viewMimeTypes)

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -50,6 +50,7 @@ export type PickerConfiguration = {
   developerKey: string
   viewId?: ViewIdOptions
   viewMimeTypes?: string
+  viewQuery?: string
   setIncludeFolders?: boolean
   setSelectFolderEnabled?: boolean
   disableDefaultView?: boolean


### PR DESCRIPTION
See https://developers.google.com/drive/picker/reference#view

For example, to filter by a file extension you would set `viewQuery: "*.jpg"`