### PR TITLE
Add prop for App ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ export default App;
 |    disableDefaultView  |  boolean  |     false     |      disables default view     |
 |    viewId        |  string  |     DOCS         |         ViewIdOptions         |
 |    viewMimeTypes |  string  |     optional     |Comma separated mimetypes. Use this in place of viewId if you need to filter multiple type of files. list: https://developers.google.com/drive/api/v3/mime-types.|
-|    viewQuery    |  string  |     optional     |Used to set a search query i.e. View.searchQuery(viewQuery) |
 |setIncludeFolders|  boolean  |     false        |Show folders in the view items.|
 |setSelectFolderEnabled|boolean|     false       |Allows the user to select a folder in Google Drive.|
 |   token          |  string  |     optional     | access_token to skip auth part|

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ function App() {
     openPicker({
       clientId: "xxxxxxxxxxxxxxxxx",
       developerKey: "xxxxxxxxxxxx",
+      appId: "xxxxxxxxxxxx",
       viewId: "DOCS",
       // token: token, // pass oauth token in case you already have one
       showUploadView: true,
@@ -71,6 +72,7 @@ export default App;
 | callbackFunction  |function    |  REQUIRED       |Callback function that will be called on picker action |
 |    clientId      |  string  |     REQUIRED     |      Google client id         |
 |    developerKey  |  string  |     REQUIRED     |      Google developer key     |
+|    appId  |  string  |     optional     |      Google app ID (optional - may be required if using drive.file scope)     |
 |    disableDefaultView  |  boolean  |     false     |      disables default view     |
 |    viewId        |  string  |     DOCS         |         ViewIdOptions         |
 |    viewMimeTypes |  string  |     optional     |Comma separated mimetypes. Use this in place of viewId if you need to filter multiple type of files. list: https://developers.google.com/drive/api/v3/mime-types.|

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export default App;
 |    disableDefaultView  |  boolean  |     false     |      disables default view     |
 |    viewId        |  string  |     DOCS         |         ViewIdOptions         |
 |    viewMimeTypes |  string  |     optional     |Comma separated mimetypes. Use this in place of viewId if you need to filter multiple type of files. list: https://developers.google.com/drive/api/v3/mime-types.|
+|    viewQuery    |  string  |     optional     |Used to set a search query i.e. View.searchQuery(viewQuery) |
 |setIncludeFolders|  boolean  |     false        |Show folders in the view items.|
 |setSelectFolderEnabled|boolean|     false       |Allows the user to select a folder in Google Drive.|
 |   token          |  string  |     optional     | access_token to skip auth part|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-google-drive-picker",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-google-drive-picker",
-      "version": "1.1.8",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^17.0.5",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,10 +69,9 @@ export default function useDrivePicker(): [
     if (!config.token) {
       const client = google.accounts.oauth2.initTokenClient({
         client_id: config.clientId,
-        scope: (config.customScopes
-          ? [...defaultScopes, ...config.customScopes]
-          : defaultScopes
-        ).join(' '),
+        scope: (config.customScopes ? config.customScopes : defaultScopes).join(
+          ' '
+        ),
         callback: (tokenResponse: authResult) => {
           setAuthRes(tokenResponse)
           createPicker({ ...config, token: tokenResponse.access_token })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -111,6 +111,7 @@ export default function useDrivePicker(): [
     showUploadFolders,
     setParentFolder = '',
     viewMimeTypes,
+    viewQuery,
     customViews,
     locale = 'en',
     setIncludeFolders,
@@ -124,6 +125,7 @@ export default function useDrivePicker(): [
     if (viewMimeTypes) view.setMimeTypes(viewMimeTypes)
     if (setIncludeFolders) view.setSelectFolderEnabled(true)
     if (setSelectFolderEnabled) view.setSelectFolderEnabled(true)
+    if (viewQuery) view.setQuery(viewQuery)
 
     const uploadView = new google.picker.DocsUploadView()
     if (viewMimeTypes) uploadView.setMimeTypes(viewMimeTypes)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,9 +69,10 @@ export default function useDrivePicker(): [
     if (!config.token) {
       const client = google.accounts.oauth2.initTokenClient({
         client_id: config.clientId,
-        scope: (config.customScopes ? config.customScopes : defaultScopes).join(
-          ' '
-        ),
+        scope: (config.customScopes
+          ? [...defaultScopes, ...config.customScopes]
+          : defaultScopes
+        ).join(' '),
         callback: (tokenResponse: authResult) => {
           setAuthRes(tokenResponse)
           createPicker({ ...config, token: tokenResponse.access_token })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,7 +101,7 @@ export default function useDrivePicker(): [
 
   const createPicker = ({
     token,
-    appId = '',
+    appId,
     supportDrives = false,
     developerKey,
     viewId = 'DOCS',
@@ -111,7 +111,6 @@ export default function useDrivePicker(): [
     showUploadFolders,
     setParentFolder = '',
     viewMimeTypes,
-    viewQuery,
     customViews,
     locale = 'en',
     setIncludeFolders,
@@ -125,7 +124,6 @@ export default function useDrivePicker(): [
     if (viewMimeTypes) view.setMimeTypes(viewMimeTypes)
     if (setIncludeFolders) view.setSelectFolderEnabled(true)
     if (setSelectFolderEnabled) view.setSelectFolderEnabled(true)
-    if (viewQuery) view.setQuery(viewQuery)
 
     const uploadView = new google.picker.DocsUploadView()
     if (viewMimeTypes) uploadView.setMimeTypes(viewMimeTypes)

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -48,9 +48,9 @@ type ViewIdOptions =
 export type PickerConfiguration = {
   clientId: string
   developerKey: string
+  AppId?: string
   viewId?: ViewIdOptions
   viewMimeTypes?: string
-  viewQuery?: string
   setIncludeFolders?: boolean
   setSelectFolderEnabled?: boolean
   disableDefaultView?: boolean

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -50,6 +50,7 @@ export type PickerConfiguration = {
   developerKey: string
   viewId?: ViewIdOptions
   viewMimeTypes?: string
+  viewQuery?: string
   setIncludeFolders?: boolean
   setSelectFolderEnabled?: boolean
   disableDefaultView?: boolean


### PR DESCRIPTION
Although the app ID isn't always required, in some cases it is needed. For example, if using the drive.file scope, the picker won't work properly without the App ID. This pull request adds the option to specify the app ID.