### PR TITLE
Making google variable accessible

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,5 +166,5 @@ export default function useDrivePicker(): [
     return true
   }
 
-  return [openPicker, authRes]
+  return [openPicker, authRes, google]
 }


### PR DESCRIPTION
Need to make `google` accessible in order to call `google.picker.Action.PICKED` or other variables from my components using the hook.

It makes writing callback function like the one below easier.

```js
callbackFunction: (data) => {
        let url = "";
        if (
          data[google.picker.Response.ACTION] === google.picker.Action.PICKED
        ) {
          let doc = data[google.picker.Response.DOCUMENTS][0];
          url = doc[google.picker.Document.URL];
        }
      }
```