### PR TITLE
add support setOwnedByMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export default App;
 |    disableDefaultView  |  boolean  |     false     |      disables default view     |
 |    viewId        |  string  |     DOCS         |         ViewIdOptions         |
 |    viewMimeTypes |  string  |     optional     |Comma separated mimetypes. Use this in place of viewId if you need to filter multiple type of files. list: https://developers.google.com/drive/api/v3/mime-types.|
+|setOwnedByMe      |  boolean |     false        |Only show owned documents. Do not combine this setting with setIncludeFolders. When setIncludeFolders is set true, setOwnedByMe is ignored.|
 |setIncludeFolders|  boolean  |     false        |Show folders in the view items.|
 |setSelectFolderEnabled|boolean|     false       |Allows the user to select a folder in Google Drive.|
 |   token          |  string  |     optional     | access_token to skip auth part|

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -116,6 +116,7 @@ export default function useDrivePicker(): [
     customViews,
     locale = 'en',
     setIncludeFolders,
+    setOwnedByMe,
     setSelectFolderEnabled,
     disableDefaultView = false,
     callbackFunction,
@@ -124,7 +125,14 @@ export default function useDrivePicker(): [
 
     const view = new google.picker.DocsView(google.picker.ViewId[viewId])
     if (viewMimeTypes) view.setMimeTypes(viewMimeTypes)
-    if (setIncludeFolders) view.setIncludeFolders(true)
+    if (setOwnedByMe){ 
+      view.setIncludeFolders(false)
+      view.setOwnedByMe(true)
+    }
+    if (setIncludeFolders) {
+      view.setIncludeFolders(true)
+      view.setOwnedByMe(false)
+    }
     if (setSelectFolderEnabled) view.setSelectFolderEnabled(true)
 
     const uploadView = new google.picker.DocsUploadView()

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -51,6 +51,7 @@ export type PickerConfiguration = {
   viewId?: ViewIdOptions
   viewMimeTypes?: string
   setIncludeFolders?: boolean
+  setOwnedByMe?: boolean
   setSelectFolderEnabled?: boolean
   disableDefaultView?: boolean
   token?: string


### PR DESCRIPTION
Hi @Jose-cd, i want to add **setOwnedByMe** for support filter owned document.
refs: https://developers.google.com/drive/picker/reference#docs-view