### PR TITLE
fix: load 'client:picker' 

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -93,7 +93,7 @@ export default function useDrivePicker(): [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     window.gapi.load('auth')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    window.gapi.load('picker', { callback: onPickerApiLoad })
+    window.gapi.load('client:picker', { callback: onPickerApiLoad })
   }
 
   const onPickerApiLoad = () => {


### PR DESCRIPTION
This change ensures we're loading the GAPI client correctly, as per the latest guidelines. Check the [docs](https://github.com/google/google-api-javascript-client/blob/master/docs/reference.md) for the new colon-separated syntax. this fixes the picker client not showing up in window.gapi .