### PR TITLE
add GRID/LIST viewMode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ export default App;
 |    disableDefaultView  |  boolean  |     false     |      disables default view     |
 |    viewId        |  string  |     DOCS         |         ViewIdOptions         |
 |    viewMimeTypes |  string  |     optional     |Comma separated mimetypes. Use this in place of viewId if you need to filter multiple type of files. list: https://developers.google.com/drive/api/v3/mime-types.|
+|    viewMode      |  string  |     optional     | can be 'GRID' or 'LIST'       |
+|    appId         |  string  |     ''           | See "Project number" under "IAM & Admin" > "Settings" in the GCP console |
 |setIncludeFolders|  boolean  |     false        |Show folders in the view items.|
 |setSelectFolderEnabled|boolean|     false       |Allows the user to select a folder in Google Drive.|
 |   token          |  string  |     optional     | access_token to skip auth part|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-google-drive-picker",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-google-drive-picker",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^17.0.5",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -113,6 +113,7 @@ export default function useDrivePicker(): [
     showUploadFolders,
     setParentFolder = '',
     viewMimeTypes,
+    viewMode,
     customViews,
     locale = 'en',
     setIncludeFolders,
@@ -124,6 +125,7 @@ export default function useDrivePicker(): [
 
     const view = new google.picker.DocsView(google.picker.ViewId[viewId])
     if (viewMimeTypes) view.setMimeTypes(viewMimeTypes)
+    if (viewMode) view.setMode(google.picker.DocsViewMode[viewMode])
     if (setIncludeFolders) view.setIncludeFolders(true)
     if (setSelectFolderEnabled) view.setSelectFolderEnabled(true)
 

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -23,13 +23,13 @@ export type PickerCallback = {
   docs: CallbackDoc[]
 }
 
-export type authResult =  {
-  access_token: string;
-  token_type: string;
-  expires_in: number;
-  scope: string;
-  authuser: string;
-  prompt: string;
+export type authResult = {
+  access_token: string
+  token_type: string
+  expires_in: number
+  scope: string
+  authuser: string
+  prompt: string
 }
 
 type ViewIdOptions =
@@ -45,11 +45,14 @@ type ViewIdOptions =
   | 'SPREADSHEETS'
   | 'PRESENTATIONS'
 
+type ViewModeOptions = 'GRID' | 'LIST'
+
 export type PickerConfiguration = {
   clientId: string
   developerKey: string
   viewId?: ViewIdOptions
   viewMimeTypes?: string
+  viewMode?: ViewModeOptions
   setIncludeFolders?: boolean
   setSelectFolderEnabled?: boolean
   disableDefaultView?: boolean


### PR DESCRIPTION
Allow to default to a Grid or List view

The reason for this change is that list view is particularly useful when using the [`drive.file` scope](https://developers.google.com/drive/api/guides/api-specific-auth#drive-scopes). This scope doesn't give you access to files that haven't been selected by the user (through the picker) explicitly, so the grid view previews are all blurred.

![drive picker grid blurry](https://github.com/Jose-cd/React-google-drive-picker/assets/1083797/1483987f-84a2-4c7f-bed2-fb3f7ca96f36)

Defaulting to list view improves UX.

[docs](https://developers.google.com/drive/picker/reference#docs-view-mode)

-----


Also added in the README the possibility to add the `appId` param, which wasn't there. This is also needed when using the `drive.file` scope, so that your app gains access to the docs.