### PR TITLE
Adding support to show shared drives on the picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-google-drive-picker",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-google-drive-picker",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^17.0.5",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -118,6 +118,7 @@ export default function useDrivePicker(): [
     setIncludeFolders,
     setSelectFolderEnabled,
     disableDefaultView = false,
+    setEnableDrives,
     callbackFunction,
   }: PickerConfiguration) => {
     if (disabled) return false
@@ -126,6 +127,7 @@ export default function useDrivePicker(): [
     if (viewMimeTypes) view.setMimeTypes(viewMimeTypes)
     if (setIncludeFolders) view.setIncludeFolders(true)
     if (setSelectFolderEnabled) view.setSelectFolderEnabled(true)
+    if (setEnableDrives) view.setEnableDrives(true)
 
     const uploadView = new google.picker.DocsUploadView()
     if (viewMimeTypes) uploadView.setMimeTypes(viewMimeTypes)

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -23,13 +23,13 @@ export type PickerCallback = {
   docs: CallbackDoc[]
 }
 
-export type authResult =  {
-  access_token: string;
-  token_type: string;
-  expires_in: number;
-  scope: string;
-  authuser: string;
-  prompt: string;
+export type authResult = {
+  access_token: string
+  token_type: string
+  expires_in: number
+  scope: string
+  authuser: string
+  prompt: string
 }
 
 type ViewIdOptions =
@@ -66,6 +66,7 @@ export type PickerConfiguration = {
   customViews?: any[]
   locale?: string
   customScopes?: string[]
+  setEnableDrives?: boolean
   callbackFunction: (data: PickerCallback) => any
 }
 


### PR DESCRIPTION
Adding support to show shared drives on the picker

![image](https://github.com/Jose-cd/React-google-drive-picker/assets/44921294/04f9bc0f-10fb-4bb4-a8ec-8d084d730e9f)
